### PR TITLE
Compatibility with NVDA 2021.1 for output reasons constants

### DIFF
--- a/addon/globalPlugins/charinfo/__init__.py
+++ b/addon/globalPlugins/charinfo/__init__.py
@@ -455,7 +455,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		### Code inspired from NVDA script_review_currentCharacter in file globalCommands.py
 		info.expand(textInfos.UNIT_CHARACTER)
 		if info.text == '':
-			reasonCaret = getattr(controlTypes, "REASON_CARET", None) or controlTypes.OutputReason.CARET
+			try:
+				reasonCaret = controlTypes.OutputReason.CARET  # NVDA 2021.1 and later
+			except AttributeError:
+				reasonCaret = controlTypes.REASON_CARET  # NVDA 2020.4 and older
 			speech.speakTextInfo(info, unit=textInfos.UNIT_CHARACTER, reason=reasonCaret)
 			return
 		font = self.getCurrCharFontName(info)

--- a/addon/globalPlugins/charinfo/__init__.py
+++ b/addon/globalPlugins/charinfo/__init__.py
@@ -455,7 +455,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		### Code inspired from NVDA script_review_currentCharacter in file globalCommands.py
 		info.expand(textInfos.UNIT_CHARACTER)
 		if info.text == '':
-			speech.speakTextInfo(info,unit=textInfos.UNIT_CHARACTER,reason=controlTypes.REASON_CARET)
+			reasonCaret = getattr(controlTypes, "REASON_CARET", None) or controlTypes.OutputReason.CARET
+			speech.speakTextInfo(info, unit=textInfos.UNIT_CHARACTER, reason=reasonCaret)
 			return
 		font = self.getCurrCharFontName(info)
 		try:


### PR DESCRIPTION
This  simply uses REASON_CARET for NVDA versions older than 2021.1 and OutputReason for 2021.1